### PR TITLE
Fix segfault when passing undefined as encodedHash parameter to verify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ function variant(hashRaw, hashEncoded, verify) {
     },
 
     verify(encoded, password, cb) {
-      const encodedBuffer = ref.allocCString(encoded);
+      const encodedBuffer = ref.allocCString(encoded || '');
       verify.async(encodedBuffer, password, password.length, (err, res) => {
         if (err) { return cb(err, null); }
         if (!errorCodes.ARGON2_OK.is(res)) {

--- a/test/argon2.js
+++ b/test/argon2.js
@@ -100,6 +100,17 @@ describe('argon2i', function () {
         done();
       });
     });
+
+    it('should reject undefined hash', function (done) {
+      var password = new Buffer('password10');
+
+      argon2i.verify(undefined, password, function (err, res) {
+        assert(err instanceof Error);
+        assert.equal(res, null);
+        assert.equal(err.message, 'ARGON2_DECODING_FAIL');
+        done();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #6. Caused by `ref.alloCString(undefined)`, which allocates a 0-length buffer. `ref` and `ffi` seem to treat this is a `NULL` pointer. `argon2_verify` does not check for a `NULL` pointer and subsequently segfaults. Opened an issue on the argon2 repo: https://github.com/P-H-C/phc-winner-argon2/issues/120
