### PR TITLE
Allow password of type string as input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,16 +21,17 @@ function parseArgs(args) {
     [password, salt, options, cb] = args;
   }
 
+  let parsedPassword = password;
+  if (typeof password === 'string') { parsedPassword = new Buffer(password); }
+
   const hashOptions = Object.assign({}, defaultOptions, options);
-  return [password, salt, hashOptions, cb];
+  return [parsedPassword, salt, hashOptions, cb];
 }
 
 function variant(hashRaw, hashEncoded, verify) {
   return {
     hashRaw(...args) {
       const [password, salt, options, cb] = parseArgs(args);
-      let parsedPassword = password;
-      if (typeof password === 'string') { parsedPassword = new Buffer(password); }
       const { timeCost, memoryCost, parallelism, hashLength } = options;
       const hashOutput = new Buffer(hashLength);
       const resultHandler = (err, res) => {
@@ -42,7 +43,7 @@ function variant(hashRaw, hashEncoded, verify) {
         return cb(null, hashOutput);
       };
       hashRaw.async(timeCost, memoryCost, parallelism,
-                    parsedPassword, parsedPassword.length,
+                    password, password.length,
                     salt, salt.length,
                     hashOutput, hashLength,
                     resultHandler);
@@ -51,8 +52,6 @@ function variant(hashRaw, hashEncoded, verify) {
 
     hash(...args) {
       const [password, salt, options, cb] = parseArgs(args);
-      let parsedPassword = password;
-      if (typeof password === 'string') { parsedPassword = new Buffer(password); }
       const { timeCost, memoryCost, parallelism, hashLength } = options;
       const encodedSize = argon2.argon2_encodedlen(timeCost, memoryCost, parallelism,
                                                    salt.length, hashLength);
@@ -66,7 +65,7 @@ function variant(hashRaw, hashEncoded, verify) {
         return cb(null, ref.readCString(outputBuffer, 0));
       };
       hashEncoded.async(timeCost, memoryCost, parallelism,
-                        parsedPassword, parsedPassword.length,
+                        password, password.length,
                         salt, salt.length,
                         hashLength,
                         outputBuffer, outputBuffer.length,

--- a/test/argon2.js
+++ b/test/argon2.js
@@ -62,6 +62,17 @@ describe('argon2i', function () {
         done();
       });
     });
+
+    it('should allow password input of type string', function (done) {
+      var salt = new Buffer('saltsalt');
+      var password = 'password1';
+      var expectedHash = '5179f7706253f090137b74004f16355341405aa657ac3ed1e9b5301326778444';
+      argon2i.hashRaw(password, salt, function (err, hashOutput) {
+        assert.ifError(err);
+        assert.equal(hashOutput.toString('hex'), expectedHash);
+        done();
+      });
+    });
   });
 
   describe('hash', function () {
@@ -76,11 +87,33 @@ describe('argon2i', function () {
         done();
       });
     });
+
+    it('should allow password input of type string', function (done) {
+      var salt = new Buffer('saltsalt');
+      var password = 'password1';
+      var expectedHash = '$argon2i$v=19$m=4096,t=3,p=1' +
+        '$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ';
+      argon2i.hash(password, salt, function (err, hashOutput) {
+        assert.ifError(err);
+        assert.equal(hashOutput.toString('hex'), expectedHash);
+        done();
+      });
+    });
   });
 
   describe('verify', function () {
     it('should verify password', function (done) {
       var password = new Buffer('password1');
+      var encodedHash = '$argon2i$v=19$m=4096,t=3,p=1' +
+        '$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ';
+      argon2i.verify(encodedHash, password, function (err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('should allow password input of type string', function (done) {
+      var password = 'password1';
       var encodedHash = '$argon2i$v=19$m=4096,t=3,p=1' +
         '$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ';
       argon2i.verify(encodedHash, password, function (err) {
@@ -125,6 +158,17 @@ describe('argon2d', function () {
         assert.equal(hashOutput.toString('hex'), expectedHash);
         done();
       });
+    });
+  });
+
+  it('should allow password input of type string', function (done) {
+    var salt = new Buffer('saltsalt');
+    var password = 'password1';
+    var expectedHash = '12d8487548a17c7856a26abf640fcdfd5ab0e4f57188292d2ef634299f43fc2f';
+    argon2d.hashRaw(password, salt, function (err, hashOutput) {
+      assert.ifError(err);
+      assert.equal(hashOutput.toString('hex'), expectedHash);
+      done();
     });
   });
 });


### PR DESCRIPTION
Allow password input of type string.
Added tests for allowing string input.
This is to address issue https://github.com/cjlarose/argon2-ffi/issues/1
