### PR TITLE
Switch FFI library to `ffi-napi`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "9"
+  - "8"
   - "6"
   - "4"
 env:

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "license": "ISC",
   "dependencies": {
     "any-promise": "^1.1.0",
-    "ffi": "^2.0.0",
-    "ref": "^1.3.2"
+    "ffi-napi": "^2.4.0",
+    "ref-napi": "^1.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import ref from 'ref';
+import ref from 'ref-napi';
 import {
   argon2ErrorMessage,
   argon2Encodedlen,

--- a/src/library.js
+++ b/src/library.js
@@ -1,5 +1,5 @@
-import ffi from 'ffi';
-import ref from 'ref';
+import ffi from 'ffi-napi';
+import ref from 'ref-napi';
 import path from 'path';
 
 const dylib = path.join(__dirname, '..', 'build', 'Release', 'argon2');


### PR DESCRIPTION
This switches the underlying library used for FFI calls from
`ffi` to `ffi-napi`, a port of `ffi` to Node’s new N-API
addon interface.

This is happening as a larger effort to increase N-API
usage in the ecosystem as a whole.

The benefits of this change for this library are:

- As it stands, `ffi` flat out doesn’t even build on Node 9
  and above – `ffi-napi` does. A patch for that has been merged
  but new releases of `ffi` have not been cut in over a year,
  and generally maintenance has seen a noticeable decrease over time.
- As with any library using N-API for their native bindings,
  big advantages are that these libraries need not be recompiled
  when a new version of Node is used, and that it is completely
  engine-independent (i.e. this code is going to work with ChakraCore
  as well, without rewriting or even just recompiling).

The only (possible) downside would be that N-API is still a
relatively new technology and that `ffi-napi` itself is still quite
young as well, so there is a slight chance of running into issues
with either technology. Just as a data point, this commit is
passing all tests on all supported versions of Node.js.

Generally, me and the Node.js N-API team would be happy to see adoption
increase and learn about any difficulties that people are running
into during that process and would really like to help address those
issues.

I hope you consider this change!