### PR TITLE
postinstall script for dev machine binary building

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "pretest": "npm run build",
     "test": "mocha --reporter spec",
     "build": "babel src -d lib",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "git submodule init && git submodule update && node-gyp rebuild && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm building on an ubuntu machine, do you think it would be okay to allow for local dev machine builds? It seems that depending on environment certain paths are changed during the make process. 