### PR TITLE
Linux specific build paths, defaults to original

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2,7 +2,15 @@ import ffi from 'ffi-napi';
 import ref from 'ref-napi';
 import path from 'path';
 
-const dylib = path.join(__dirname, '..', 'build', 'Release', 'argon2');
+const preamble = [__dirname, '..', 'build', 'Release'];
+const osvar = process.platform;
+const platforms = {
+  linux: ['lib.target', 'argon2'],
+};
+
+const platformPath = platforms[osvar] || ['argon2'];
+const finalPath = preamble.concat(platformPath);
+const dylib = path.join(...finalPath);
 const lib = new ffi.Library(dylib, {
   argon2i_hash_encoded: ['int', ['uint32', 'uint32', 'uint32',    // t_cost, m_cost, p
                                  ref.refType('void'), 'size_t',   // password

--- a/src/library.js
+++ b/src/library.js
@@ -1,10 +1,13 @@
 import ffi from 'ffi-napi';
 import ref from 'ref-napi';
 import path from 'path';
+import fs from 'fs';
 
 function loadLib(filename, fallback) {
   try {
-    require(filename);
+    if (!fs.existsSync(filename)) {
+      throw new Error('Missing default target');
+    }
     return filename;
   } catch (e) {
     return fallback;

--- a/src/library.js
+++ b/src/library.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 
 function loadLib(filename, fallback) {
   try {
-    if (!fs.existsSync(filename)) {
+    if (!fs.existsSync(`${filename}.so`)) {
       throw new Error('Missing default target');
     }
     return filename;

--- a/src/library.js
+++ b/src/library.js
@@ -2,15 +2,18 @@ import ffi from 'ffi-napi';
 import ref from 'ref-napi';
 import path from 'path';
 
-const preamble = [__dirname, '..', 'build', 'Release'];
-const osvar = process.platform;
-const platforms = {
-  linux: ['lib.target', 'argon2'],
-};
+function loadLib(filename, fallback) {
+  try {
+    require(filename);
+    return filename;
+  } catch (e) {
+    return fallback;
+  }
+}
 
-const platformPath = platforms[osvar] || ['argon2'];
-const finalPath = preamble.concat(platformPath);
-const dylib = path.join(...finalPath);
+const defaultTarget = path.join(__dirname, '..', 'build', 'Release', 'argon2');
+const linuxTarget = path.join(__dirname, '..', 'build', 'Release', 'lib.target', 'argon2');
+const dylib = loadLib(defaultTarget, linuxTarget);
 const lib = new ffi.Library(dylib, {
   argon2i_hash_encoded: ['int', ['uint32', 'uint32', 'uint32',    // t_cost, m_cost, p
                                  ref.refType('void'), 'size_t',   // password


### PR DESCRIPTION
Seems in Ubuntu 18, that the lib builds the `.so` in `build/Release/lib.target/argon2.so`. This change will look for linux, but default to the original path if the platform is not linux. 