### PR TITLE
Resolve output path for node-gyp binaries

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2,7 +2,7 @@ import ffi from 'ffi-napi';
 import ref from 'ref-napi';
 import path from 'path';
 
-const dylib = path.join(__dirname, '..', 'build', 'Release', 'argon2');
+const dylib = path.join(__dirname, '..', 'build', 'Release', 'obj.target', 'argon2');
 const lib = new ffi.Library(dylib, {
   argon2i_hash_encoded: ['int', ['uint32', 'uint32', 'uint32',    // t_cost, m_cost, p
                                  ref.refType('void'), 'size_t',   // password


### PR DESCRIPTION
Changed the path to now include obj.target to avoid issues related to indeterminate node-gyp versions.

Fixes #28