### PR TITLE
Drop support for old NodeJS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "11"
   - "10"
-  - "8"
-  - "6"
+  - "12"
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
Support for only Active LTS and Maintenance LTS releases

https://nodejs.org/en/about/releases/

I'll consider this a breaking change for semver purposes. Next release will be 2.x