### PR TITLE
Fix Buffer constructor deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ This module exports `argon2i` and `argon2d`. These are two variants
 of `argon2` with different use-cases and tradeoffs. To find which
 one you should use, refer to the [`argon2` repo][argon2].
 
-
 ### Hashing a password
 
 ```javascript
-var argon2i = require('argon2-ffi').argon2i;
+var argon2i = require("argon2-ffi").argon2i;
 // var argon2d = require('argon2-ffi').argon2d; if you'd like to use argon2d
-var crypto = require('crypto');
-var Promise = require('bluebird');
+var crypto = require("crypto");
+var Promise = require("bluebird");
 var randomBytes = Promise.promisify(crypto.randomBytes);
 
-var password = 'password1'; // Can also be a Buffer
-randomBytes(32).then(salt => argon2i.hash(password, salt))
+var password = "password1"; // Can also be a Buffer
+randomBytes(32)
+  .then((salt) => argon2i.hash(password, salt))
   .then(console.log); // $argon2i$v=19$m=4096,t=3,p=1$c2FsdHlzYWx0$oG0js25z7kM30xSg9+nAKtU0hrPa0UnvRnqQRZXHCV8
 ```
 
@@ -51,14 +51,20 @@ to be cryptographically secure. However, you can of course use your own buffer.
 have an effect on the output hash.
 
 ```javascript
-var argon2i = require('argon2-ffi').argon2i;
-var crypto = require('crypto');
-var Promise = require('bluebird');
+var argon2i = require("argon2-ffi").argon2i;
+var crypto = require("crypto");
+var Promise = require("bluebird");
 var randomBytes = Promise.promisify(crypto.randomBytes);
 
-var password = new Buffer('password1');
-var options = { timeCost: 4, memoryCost: 1 << 14, parallelism: 2, hashLength: 64 };
-randomBytes(32).then(salt => argon2i.hash(password, salt, options))
+var password = new Buffer("password1");
+var options = {
+  timeCost: 4,
+  memoryCost: 1 << 14,
+  parallelism: 2,
+  hashLength: 64,
+};
+randomBytes(32)
+  .then((salt) => argon2i.hash(password, salt, options))
   .then(console.log); // $argon2i$v=19$m=16384,t=4,p=2$c2FsdHlzYWx0$gwJY/FsXNSR3aS1ChVTgDZ9HbF3V7sbbYE5UmQsdXFHB4Tt6/RVtFWGIIJnzZ62nL9miurrvJnxhvORK64ddFg
 ```
 
@@ -69,12 +75,16 @@ as we'll see in the next section.
 ### Verifying a password
 
 ```javascript
-var argon2i = require('argon2-ffi').argon2i;
+var argon2i = require("argon2-ffi").argon2i;
 
-var encodedHash = "$argon2i$v=19$m=4096,t=3,p=1$c2FsdHlzYWx0$oG0js25z7kM30xSg9+nAKtU0hrPa0UnvRnqQRZXHCV8";
-var password = new Buffer('password1');
-argon2i.verify(encodedHash, password)
-  .then(correct => console.log(correct ? 'Correct password!' : 'Incorrect password'));
+var encodedHash =
+  "$argon2i$v=19$m=4096,t=3,p=1$c2FsdHlzYWx0$oG0js25z7kM30xSg9+nAKtU0hrPa0UnvRnqQRZXHCV8";
+var password = new Buffer("password1");
+argon2i
+  .verify(encodedHash, password)
+  .then((correct) =>
+    console.log(correct ? "Correct password!" : "Incorrect password")
+  );
 ```
 
 ### Differences from node-argon2
@@ -83,7 +93,7 @@ argon2i.verify(encodedHash, password)
 with running [`node-argon2`][node-argon2] in a web server. This was a
 non-starter for my own projects. By using `node-ffi`, `argon2-ffi` was able to
 circumvent the problems `node-argon2` had with Promises. `node-argon2` has
-since resolved this issue.  `argon2-ffi` also returned Promises with
+since resolved this issue. `argon2-ffi` also returned Promises with
 `any-promise`, but this has since been implemented in `node-argon2` as well.
 Today, the practical differences between the two libraries are only in the
 public APIs.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var crypto = require("crypto");
 var Promise = require("bluebird");
 var randomBytes = Promise.promisify(crypto.randomBytes);
 
-var password = new Buffer("password1");
+var password = Buffer.from("password1");
 var options = {
   timeCost: 4,
   memoryCost: 1 << 14,
@@ -79,7 +79,7 @@ var argon2i = require("argon2-ffi").argon2i;
 
 var encodedHash =
   "$argon2i$v=19$m=4096,t=3,p=1$c2FsdHlzYWx0$oG0js25z7kM30xSg9+nAKtU0hrPa0UnvRnqQRZXHCV8";
-var password = new Buffer("password1");
+var password = Buffer.from("password1");
 argon2i
   .verify(encodedHash, password)
   .then((correct) =>

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ const defaultOptions = {
 
 function parseArgs([password, salt, options = {}]) {
   if (typeof password === "string") {
-    password = new Buffer(password);
+    password = Buffer.from(password);
   }
   options = Object.assign({}, defaultOptions, options);
 
@@ -35,7 +35,7 @@ function variant(hashRaw, hashEncoded, verify) {
     hashRaw(...args) {
       const [password, salt, options] = parseArgs(args);
       const { timeCost, memoryCost, parallelism, hashLength } = options;
-      const hashOutput = new Buffer(hashLength);
+      const hashOutput = Buffer.alloc(hashLength);
       const promise = new Promise((resolve, reject) => {
         const resultHandler = (err, res) => {
           if (err) {
@@ -72,7 +72,7 @@ function variant(hashRaw, hashEncoded, verify) {
         salt.length,
         hashLength
       );
-      const outputBuffer = new Buffer(encodedSize);
+      const outputBuffer = Buffer.alloc(encodedSize);
       const promise = new Promise((resolve, reject) => {
         const resultHandler = (err, res) => {
           if (err) {
@@ -104,7 +104,7 @@ function variant(hashRaw, hashEncoded, verify) {
       const encodedBuffer = ref.allocCString(encoded || "");
       let parsedPassword = password;
       if (typeof password === "string") {
-        parsedPassword = new Buffer(password);
+        parsedPassword = Buffer.from(password);
       }
       const promise = new Promise((resolve, reject) => {
         const resultHandler = (err, res) => {

--- a/test/argon2.js
+++ b/test/argon2.js
@@ -7,8 +7,8 @@ var argon2d = require("../lib/index").argon2d;
 describe("argon2i", function () {
   describe("hashRaw", function () {
     it("should return correct hash", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var expectedHash =
         "5179f7706253f090137b74004f16355341405aa657ac3ed1e9b5301326778444";
       return argon2i
@@ -17,8 +17,8 @@ describe("argon2i", function () {
     });
 
     it("should allow changing timeCost", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var expectedHash =
         "188baa8a1acbad59af6d3acfaa8a63b6845e64ac4d95c7be8b29ea9c00e2edcb";
       return argon2i
@@ -27,8 +27,8 @@ describe("argon2i", function () {
     });
 
     it("should allow changing memoryCost", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var expectedHash =
         "f7b4b5b0c30976cdf3137281a31a0573e0335723882388320069b58b94793fb7";
       return argon2i
@@ -37,8 +37,8 @@ describe("argon2i", function () {
     });
 
     it("should allow changing parallelism", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var expectedHash =
         "804a7d9ed278d4125e5bfb710972ad105235227215a3f9e7c2cda304f7d4b81d";
       var options = { memoryCost: 1 << 16, parallelism: 2 };
@@ -48,8 +48,8 @@ describe("argon2i", function () {
     });
 
     it("should return error codes", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var options = { timeCost: 2, memoryCost: 1, parallelism: 1 };
       return argon2i
         .hashRaw(password, salt, options)
@@ -61,7 +61,7 @@ describe("argon2i", function () {
     });
 
     it("should allow password input of type string", function () {
-      var salt = new Buffer("saltsalt");
+      var salt = Buffer.from("saltsalt");
       var password = "password1";
       var expectedHash =
         "5179f7706253f090137b74004f16355341405aa657ac3ed1e9b5301326778444";
@@ -73,8 +73,8 @@ describe("argon2i", function () {
 
   describe("hash", function () {
     it("should return encoded hash", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var expectedEncoding =
         "$argon2i$v=19$m=4096,t=3,p=1" +
         "$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ";
@@ -84,7 +84,7 @@ describe("argon2i", function () {
     });
 
     it("should allow password input of type string", function () {
-      var salt = new Buffer("saltsalt");
+      var salt = Buffer.from("saltsalt");
       var password = "password1";
       var expectedHash =
         "$argon2i$v=19$m=4096,t=3,p=1" +
@@ -97,7 +97,7 @@ describe("argon2i", function () {
 
   describe("verify", function () {
     it("should verify password", function () {
-      var password = new Buffer("password1");
+      var password = Buffer.from("password1");
       var encodedHash =
         "$argon2i$v=19$m=4096,t=3,p=1" +
         "$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ";
@@ -117,7 +117,7 @@ describe("argon2i", function () {
     });
 
     it("should resolve false for a bad password", function () {
-      var password = new Buffer("password10");
+      var password = Buffer.from("password10");
       var encodedHash =
         "$argon2i$v=19$m=4096,t=3,p=1" +
         "$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ";
@@ -127,7 +127,7 @@ describe("argon2i", function () {
     });
 
     it("should reject undefined hash", function () {
-      var password = new Buffer("password10");
+      var password = Buffer.from("password10");
 
       return argon2i
         .verify(undefined, password)
@@ -143,8 +143,8 @@ describe("argon2i", function () {
 describe("argon2d", function () {
   describe("hashRaw", function () {
     it("should return correct hash", function () {
-      var salt = new Buffer("saltsalt");
-      var password = new Buffer("password1");
+      var salt = Buffer.from("saltsalt");
+      var password = Buffer.from("password1");
       var expectedHash =
         "12d8487548a17c7856a26abf640fcdfd5ab0e4f57188292d2ef634299f43fc2f";
       return argon2d
@@ -154,7 +154,7 @@ describe("argon2d", function () {
   });
 
   it("should allow password input of type string", function () {
-    var salt = new Buffer("saltsalt");
+    var salt = Buffer.from("saltsalt");
     var password = "password1";
     var expectedHash =
       "12d8487548a17c7856a26abf640fcdfd5ab0e4f57188292d2ef634299f43fc2f";

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,11 +1,11 @@
-import { argon2i, argon2d } from 'argon2-ffi';
+import { argon2i, argon2d } from "argon2-ffi";
 
-const salt = new Buffer('saltsalt');
-const password = new Buffer('password1');
+const salt = new Buffer("saltsalt");
+const password = new Buffer("password1");
 const options = { memoryCost: 1 << 16, parallelism: 2 };
 const encodedHash =
-  '$argon2i$v=19$m=4096,t=3,p=1' +
-  '$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ';
+  "$argon2i$v=19$m=4096,t=3,p=1" +
+  "$c2FsdHNhbHQ$UXn3cGJT8JATe3QATxY1U0FAWqZXrD7R6bUwEyZ3hEQ";
 argon2i.hash(password, salt);
 argon2i.hashRaw(password, salt, { timeCost: 5 });
 argon2i.hashRaw(password, salt, { memoryCost: 1 << 14 });

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,7 +1,7 @@
 import { argon2i, argon2d } from "argon2-ffi";
 
-const salt = new Buffer("saltsalt");
-const password = new Buffer("password1");
+const salt = Buffer.from("saltsalt");
+const password = Buffer.from("password1");
 const options = { memoryCost: 1 << 16, parallelism: 2 };
 const encodedHash =
   "$argon2i$v=19$m=4096,t=3,p=1" +


### PR DESCRIPTION
https://nodejs.org/en/docs/guides/buffer-constructor-deprecation

This change doesn't introduce any breaking API changes since all supported Node versions (Active LTS and maintenance LTS) support the new constructors. It does, however, update the recommend usage of the library.

Related issue: #39